### PR TITLE
Fix env value quoting for write_env_script

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -390,7 +390,10 @@ class Pathname
       args = nil
     end
     env_export = +""
-    env.each { |key, value| env_export << "#{key}=\"#{value}\" " }
+    env.each do |key, value|
+      escaped = value.to_s.gsub("\\", "\\\\").gsub('"', '\\"')
+      env_export << "#{key}=\"#{escaped}\" "
+    end
     dirname.mkpath
     write <<~SH
       #!/bin/bash

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -298,4 +298,16 @@ RSpec.describe Pathname do
       expect(file/".DS_Store").to be_ds_store
     end
   end
+
+  describe "#write_env_script" do
+    it "escapes special characters in environment values" do
+      script = dst/"wrapper"
+      script.write_env_script "/bin/echo", FOO: "bar\"baz\\qux"
+
+      expect(File.read(script)).to eq <<~SH
+        #!/bin/bash
+        FOO="bar\"baz\\qux" exec "/bin/echo" "$@"
+      SH
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- escape special characters when creating env wrapper scripts
- test that special characters are properly escaped

## Testing
- `./bin/brew tests` *(fails: failed to install the 'bundler' gem)*

------
https://chatgpt.com/codex/tasks/task_e_683f8729ec0c8327a300d606b4d88260