### PR TITLE
Fix typo, bug and add pluralize test

### DIFF
--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -26,8 +26,8 @@ module Cask
       # Extension module for script installers.
       module ScriptInstaller
         def install_phase(command: nil, **_)
-          # TODO: The `T.unsafe` is a false positive that is unnecessary in newer releasese of Sorbet
-          # (confirmend with sorbet v0.5.10672)
+          # TODO: The `T.unsafe` is a false positive that is unnecessary in newer releases of Sorbet
+          # (confirmed with sorbet v0.5.10672)
           ohai "Running #{T.unsafe(self.class).dsl_key} script '#{path}'"
 
           executable_path = staged_path_join_executable(path)

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -29,7 +29,11 @@ module Homebrew
         largest_monthly_amount = T.let(0, T.untyped)
 
         GitHub.sponsorships("Homebrew").each do |s|
-          largest_monthly_amount = [s[:monthly_amount], s[:closest_tier_monthly_amount]].max
+        largest_monthly_amount = [
+          largest_monthly_amount,
+          s[:monthly_amount],
+          s[:closest_tier_monthly_amount]
+        ].max
           if largest_monthly_amount >= NAMED_MONTHLY_AMOUNT
             named_sponsors << "[#{sponsor_name(s)}](#{sponsor_url(s)})"
           end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe Utils do
       expect(described_class.pluralize("foo", 1, include_count: true)).to eq("1 foo")
       expect(described_class.pluralize("foo", 2, include_count: true)).to eq("2 foos")
     end
+
+    it "handles negative counts" do
+      expect(described_class.pluralize("foo", -1)).to eq("foos")
+      expect(described_class.pluralize("foo", -1, include_count: true)).to eq("-1 foos")
+    end
   end
 
   describe ".underscore" do

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Version do
     end
   end
 
-  it "implicitlys converts to a string" do
+  it "implicitly converts to a string" do
     expect(String.try_convert(version)).to eq "1.2.3"
   end
 


### PR DESCRIPTION
## Summary
- fix spelling in `version_spec.rb`
- update sponsor calculation to retain max value
- correct comment typos in installer
- test Utils.pluralize with negative counts

## Testing
- `bin/brew style Library/Homebrew/cask/artifact/installer.rb` *(fails: failed to install the 'bundler' gem)*
- `bin/brew typecheck` *(fails: failed to install the 'bundler' gem)*
- `bin/brew tests` *(fails: failed to install the 'bundler' gem)*
- `bin/brew tests --only=Library/Homebrew/test/utils_spec.rb` *(fails: failed to install the 'bundler' gem)*

------
https://chatgpt.com/codex/tasks/task_e_683f872a502083279e3c99baaff4c59e